### PR TITLE
Delete unneeded error raising

### DIFF
--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -151,10 +151,8 @@ module Licensed
     #
     # Raises Licensed::Configuration::LoadError if a file isn't found
     def self.find_config(directory)
-      config_file = DEFAULT_CONFIG_FILES.map { |file| directory.join(file) }
-                                        .find { |file| file.exist? }
-
-      config_file || raise(LoadError, "Licensed configuration not found in #{directory}")
+      DEFAULT_CONFIG_FILES.map { |file| directory.join(file) }
+                          .find { |file| file.exist? }
     end
 
     # Parses the configuration given at `config_path` and returns the values
@@ -162,7 +160,7 @@ module Licensed
     #
     # Raises Licensed::Configuration::LoadError if the file type isn't known
     def self.parse_config(config_path)
-      return {} unless config_path.file?
+      return {} unless config_path&.file?
 
       extension = config_path.extname.downcase.delete "."
       config = case extension


### PR DESCRIPTION
This error raised when you run for example `licensed cache` without some config file. If you just add config file without any line, everything works because of checking inside parse_config.